### PR TITLE
Fix #52 - Autoplay settings aren't properly setup. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -129,10 +129,9 @@ if [ $(lsb_release -rs) = '18.3' ]; then
     # Volman controls autoplay settings for xfce
     if [ $(dpkg-query -W -f='${Status}' thunar-volman 2>/dev/null | grep -c "ok installed") -eq 1 ]; then
         echo "Setting up autoplay for linux mint"
-        xfconf-query -c thunar-volman -p /autoplay-audio-cds/command -s "/usr/bin/vlc cdda://%d"
-        xfconf-query -c thunar-volman -p /autoplay-audio-cds/enabled -s true
-        xfconf-query -c thunar-volman -p /autoplay-video-cds/command -s "/usr/bin/vlc dvd://%d"
-        xfconf-query -c thunar-volman -p /autoplay-video-cds/enabled -s true
+        # Note: A reboot or logout/login is required for these settings to take effect.
+        xfconf-query -c thunar-volman -n -t string -p /autoplay-audio-cds/command -s "/usr/bin/vlc cdda://"
+        xfconf-query -c thunar-volman -n -t string -p /autoplay-video-cds/command -s "/usr/bin/vlc dvd://"
     fi
 
     # Add additional mint packages here


### PR DESCRIPTION
My previous 'fix' for #52 hasn't been working properly. When I tested autoplay settings last Sunday, the script wasn't properly updating the autoplay settings, despite my changes. I didn't notice this when I initially added the lines because I wasn't testing on a completely fresh system. Today, I used VirtualBox's 'snapshots' feature to make sure I was starting with a fresh system every time I ran the command and was able to track down the issue. 

One thing to note though: **After the script is run, you will need to either logout or reboot for these changes to take effect**, so if you ignore the 'reboot' prompt that appears when the script is done, the autoplay settings will not be properly set. 