### PR TITLE
Add script to undo "prepare for shipping to end user"

### DIFF
--- a/undo-prepare-for-shipping-to-end-user.sh
+++ b/undo-prepare-for-shipping-to-end-user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script attempts to undo the results of oem-config-prepare, which is called 
+# when a user clicks 'Prepare for shipping to end user'
+if [ "$(id -u)" = 0 ]; then
+    set -x # For easier debugging, print commands as they run
+    /bin/systemctl disable oem-config.service
+    /bin/systemctl disable oem-config.target
+    rm -f /lib/systemd/system/oem-config.service /lib/systemd/system/oem-config.target
+else
+    echo "Error: This script must be run as root. try running:"
+    echo "sudo $0"
+    exit 1
+fi     


### PR DESCRIPTION
Last week at FreeGeek I noticed several computers come back from QA because someone pushed 'prepare for shipping to end user'. Pushing this button makes the first time configuration menu show up on the next bootup, and there is no way to exit it from the UI. This meant that QA couldn't run any of the QA scripts on these machines, so mint had to be completely reinstalled, a 1hr+ process. 

![capture](https://user-images.githubusercontent.com/9411156/38774421-f67ad566-402d-11e8-98d6-71781ae4c911.PNG)

I did some digging and it looks like the script run when a user clicks the 'prepare for shipping to end user' button, adds a service called oem-config and sets it to run on bootup. I wrote a quick script to undo that.

To run this script on a computer that's stuck at the first time configuration menu, do the following
1. When the 'welcome' screen pictured above shows up, push Ctrl + Alt + F2. The screen will go blank for a bit, then prompt you for a username and password. Enter `oem` for the username and `password` for the password.

![capture](https://user-images.githubusercontent.com/9411156/38774422-19da63d2-402e-11e8-82d5-4f65d90ae024.PNG)

2. Run `wget -O undo.sh https://git.io/vpeiv` to download the script.
- [ ] TODO: Once this is merged, we'll need to update the git.io url for the script.
3. Run the script with `sudo bash ./undo.sh`

![capture](https://user-images.githubusercontent.com/9411156/38774460-4c1179e8-402f-11e8-8e75-dc0114f40152.PNG)

4. Run `sudo reboot` to restart the machine. You've just saved yourself over an hour of work!


