### PR TITLE
Add vlc to install script to ensure it's installed properly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,9 +156,12 @@ fi
 ###############################
 # firmware-b43-installer is firmware for Broadcom wireless cards and TV capture cards
 # everything that ends in -es is for spanish language support
+# vlc is normally installed with mint automatically, but we've had issues where sometimes it's not installed if
+# there's no network connectivity during the install process. We've included it below to solve the issue.
 log_pretty "Installing common packages for all releases"
 apt install -y \
 	libreoffice \
+	vlc \
 	ubuntu-restricted-extras \
 	libdvdcss2 \
 	gimp \


### PR DESCRIPTION
Today, I was building a machine and noticed autoplay wasn't working. This was because vlc wasn't installed at all. Normally it comes with mint but I guess it wasn't installed for some reason. I believe this happened because I left the network cable unplugged during the install process, but I'm not certain. I've added it here to make sure it's always installed.